### PR TITLE
Fix pool init hash

### DIFF
--- a/contracts/libraries/PoolAddress.sol
+++ b/contracts/libraries/PoolAddress.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.5.0;
 
 /// @title Provides functions for deriving a pool address from the factory, tokens, and the fee
 library PoolAddress {
-    bytes32 internal constant POOL_INIT_CODE_HASH = 0xa598dd2fba360510c5a8f02f44423a4468e902df5857dbce3ca162a43a3a31ff;
+    bytes32 internal constant POOL_INIT_CODE_HASH = 0xe34f199b19b2b4f47f68442619d555527d244f78a3297ea89325f843f87b8b54;
 
     /// @notice The identifying key of the pool
     struct PoolKey {


### PR DESCRIPTION
pool init hash was incorrectly updated in 0.8 branch, which deviates from the init hash that is actually used to deploy pools based on the code in core.